### PR TITLE
Replace fixed height with max-height for cover images

### DIFF
--- a/src/components/entry.astro
+++ b/src/components/entry.astro
@@ -43,7 +43,7 @@ const { Content } = await entry.render();
   hasFrontmatter && (
     <>
       {coverImageTop && (
-        <img src={coverImage} alt="" class="h-48 sm:h-54 w-auto mx-auto" />
+        <img src={coverImage} alt="" class="max-h-48 sm:max-h-54 w-auto mx-auto" />
       )}
 
       {title && (
@@ -87,7 +87,7 @@ const { Content } = await entry.render();
 
   {
     coverImageBottom && (
-      <img src={coverImage} alt="" class="mt-18 h-48 sm:h-54 w-auto mx-auto" />
+      <img src={coverImage} alt="" class="mt-18 max-h-48 sm:max-h-54 w-auto mx-auto" />
     )
   }
 </div>


### PR DESCRIPTION
## Summary
Updated cover image styling to use `max-height` instead of fixed `height` constraints, allowing images to scale down responsively while maintaining their aspect ratio.

## Changes
- Changed top cover image from `h-48 sm:h-54` to `max-h-48 sm:max-h-54`
- Changed bottom cover image from `h-48 sm:h-54` to `max-h-48 sm:max-h-54`

## Details
This change improves responsive image handling by setting maximum height constraints rather than fixed heights. Images will now scale down on smaller viewports while respecting the defined max-height breakpoints, providing better flexibility and preventing layout issues on devices with limited vertical space.

https://claude.ai/code/session_01Maumafzxa4sFmFT4qe4uCJ